### PR TITLE
fallback to the general base if user or group base was not set. Fixes #4

### DIFF
--- a/lib/LDAPConnect.php
+++ b/lib/LDAPConnect.php
@@ -107,11 +107,19 @@ class LDAPConnect {
 	}
 
 	public function getLDAPBaseUsers() {
-		return $this->ldapConfig->ldapBaseUsers;
+		$bases = $this->ldapConfig->ldapBaseUsers;
+		if(empty($bases)) {
+			$bases = $this->ldapConfig->ldapBase;
+		}
+		return $bases;
 	}
 
 	public function getLDAPBaseGroups() {
-		return $this->ldapConfig->ldapBaseGroups;
+		$bases = $this->ldapConfig->ldapBaseGroups;
+		if(empty($bases)) {
+			$bases = $this->ldapConfig->ldapBase;
+		}
+		return $bases;
 	}
 
 	public function getDisplayNameAttribute() {

--- a/tests/integration/features/user.feature
+++ b/tests/integration/features/user.feature
@@ -35,6 +35,19 @@ Feature: user
     And the created users resides on LDAP
 
   # requires NC 17
+  Scenario: create a new user with dynamic user id without user base set
+    Given As an "admin"
+    And parameter "newUser.generateUserID" of app "core" is set to "yes"
+    And modify LDAP configuration
+      | ldapBaseUsers |  |
+    When creating a user with
+      | userid |  |
+      | password | 123456 |
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the created users resides on LDAP
+
+  # requires NC 17
   Scenario: create a new user with dynamic user id
     Given As an "admin"
     And parameter "newUser.generateUserID" of app "core" is set to "yes"


### PR DESCRIPTION
a short cut to the LDAP config is used (because this is not provided by the ILDAPProivder yet), which does not profit from the fallback logic from the LDAP backend.