### PR TITLE
Set password through LDAP passwd exop when creating user

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -54,7 +54,7 @@ kind: pipeline
 name: integration-master
 steps:
   - name: integration
-    image: nextcloudci/php7.1:php7.1-16
+    image: nextcloudci/php7.2:php7.2-12
     environment:
       APP_NAME: ldap_write_support
       CORE_BRANCH: master
@@ -99,7 +99,7 @@ kind: pipeline
 name: integration-master-nocache
 steps:
   - name: integration
-    image: nextcloudci/php7.1:php7.1-16
+    image: nextcloudci/php7.2:php7.2-12
     environment:
       APP_NAME: ldap_write_support
       CORE_BRANCH: master

--- a/lib/LDAPUserManager.php
+++ b/lib/LDAPUserManager.php
@@ -254,6 +254,22 @@ class LDAPUserManager implements ILDAPUserPlugin {
 		if (!$ret && $this->configuration->isPreventFallback()) {
 			throw new \Exception('Cannot create user: ' . ldap_error($connection), ldap_errno($connection));
 		}
+
+		// Set password through ldap password exop, if supported
+		if ($this->respondToActions() & Backend::SET_PASSWORD) {
+			try {
+				$ret = ldap_exop_passwd($connection, $newUserDN, '', $password);
+				if ($ret === false) {
+					$message = 'Failed to set password for new user {dn}';
+					$this->logger->log(ILogger::ERROR, $message, [
+						'app' => Application::APP_ID,
+						'dn' => $newUserDN,
+					]);
+				}
+			} catch (\Exception $e) {
+				$this->logger->logException($e, ['app' => Application::APP_ID]);
+			}
+		} 
 		return $ret ? $newUserDN : false;
 	}
 

--- a/lib/Service/Configuration.php
+++ b/lib/Service/Configuration.php
@@ -63,8 +63,7 @@ class Configuration {
 			'uid: {UID}' . PHP_EOL .
 			'displayName: {UID}' . PHP_EOL .
 			'cn: {UID}' . PHP_EOL .
-			'sn: {UID}' . PHP_EOL .
-			'userPassword: {PWD}';
+			'sn: {UID}';
 	}
 
 	public function isRequireEmail(): bool {


### PR DESCRIPTION
This avoids storing plain-text passwords in LDAP.

Closes #86 