### PR TITLE
Fix account creation with the registration app

### DIFF
--- a/lib/LDAPUserManager.php
+++ b/lib/LDAPUserManager.php
@@ -217,6 +217,11 @@ class LDAPUserManager implements ILDAPUserPlugin {
 			throw new Exception('Acting user is not from LDAP');
 		}
 		try {
+			// $adminUser can be null, for example when using the registration app,
+			// throw an Exception to fallback on using the global LDAP connection.
+			if ($adminUser === null) {
+				throw new Exception('No admin user available');
+			}
 			$connection = $this->ldapProvider->getLDAPConnection($adminUser->getUID());
 			// TODO: what about multiple bases?
 			$base = $this->ldapProvider->getLDAPBaseUsers($adminUser->getUID());


### PR DESCRIPTION
When an account is created from the registration app there is no user session. This lead to an Error in createUser() as $adminUser is used while null, but only Exceptions are cought there.

Add a check that throw an Exception when $adminUser is null to fallback in the code path that handle the case where the admin user is not from the LDAP directory.

The documentation should perhaps also mention that using the "admin must be from LDAP" feature is not compatible with the registration app.