### PR TITLE
Fix new account template

### DIFF
--- a/lib/LDAPUserManager.php
+++ b/lib/LDAPUserManager.php
@@ -265,6 +265,17 @@ class LDAPUserManager implements ILDAPUserPlugin {
 	}
 
 	public function buildNewEntry($username, $password, $base) {
+		// Make sure the parameters don't fool the following algorithm
+		if (strpos($username, PHP_EOL) !== false) {
+			throw new Exception('Username contains a new line');
+		}
+		if (strpos($password, PHP_EOL) !== false) {
+			throw new Exception('Password contains a new line');
+		}
+		if (strpos($base, PHP_EOL) !== false) {
+			throw new Exception('Base DN contains a new line');
+		}
+
 		$ldif = $this->configuration->getUserTemplate();
 
 		$ldif = str_replace('{UID}', $username, $ldif);


### PR DESCRIPTION
Fix creating accounts with colon in the password (issue #81) and obvious LDAP injection (issue #145).