### PR TITLE
Update LDAPUserManager.php error in split with ':'

### DIFF
--- a/lib/LDAPUserManager.php
+++ b/lib/LDAPUserManager.php
@@ -274,7 +274,7 @@ class LDAPUserManager implements ILDAPUserPlugin {
 		$entry = [];
 		$lines = explode(PHP_EOL, $ldif);
 		foreach ($lines as $line) {
-			$split = explode(':', $line);
+			$split = explode(':', $line, 2);
 			$key = trim($split[0]);
 			$value = trim($split[1]);
 			if (!isset($entry[$key])) {


### PR DESCRIPTION
Doesn't just split the first ':', example the following mailstoragedirectory attribute: maildir:/var/mail/ in ldap is saved
mailstoragedirectory: maildir. But adding limit 2 saves correctly.