### PR TITLE
Add a new group template just as it is already there for adding users.

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -77,6 +77,7 @@ class Application extends App {
 
 		$this->ldapGroupManager = new LDAPGroupManager(
 			$s->getGroupManager(),
+			$s->getUserSession(),
 			$ldapConnect,
 			$s->getLogger(),
 			$provider

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -79,8 +79,10 @@ class Application extends App {
 			$s->getGroupManager(),
 			$s->getUserSession(),
 			$ldapConnect,
-			$s->getLogger(),
-			$provider
+			$provider,
+			$c->query(Configuration::class),
+			$s->getL10N(self::APP_ID),
+			$s->getLogger()
 		);
 
 		/** @var UserPluginManager $userPluginManager */

--- a/lib/LDAPGroupManager.php
+++ b/lib/LDAPGroupManager.php
@@ -28,13 +28,16 @@ namespace OCA\LdapWriteSupport;
 use Exception;
 use OC\Group\Backend;
 use OCA\LdapWriteSupport\AppInfo\Application;
+use OCA\LdapWriteSupport\Service\Configuration;
 use OCA\User_LDAP\Group_Proxy;
 use OCA\User_LDAP\ILDAPGroupPlugin;
 use OCA\User_LDAP\LDAPProvider;
 use OCP\AppFramework\QueryException;
 use OCP\IGroupManager;
-use OCP\IUserSession;
+use OCP\IL10N;
 use OCP\ILogger;
+use OCP\IUser;
+use OCP\IUserSession;
 use OCP\LDAP\ILDAPProvider;
 
 class LDAPGroupManager implements ILDAPGroupPlugin {
@@ -53,12 +56,14 @@ class LDAPGroupManager implements ILDAPGroupPlugin {
 	/** @var ILogger */
 	private $logger;
 
-	public function __construct(IGroupManager $groupManager, IUserSession $userSession, LDAPConnect $ldapConnect, ILogger $logger, ILDAPProvider $ldapProvider) {
+	public function __construct(IGroupManager $groupManager, IUserSession $userSession, LDAPConnect $ldapConnect, ILDAPProvider $ldapProvider, Configuration $configuration, IL10N $l10n, ILogger $logger) {
 		$this->groupManager = $groupManager;
 		$this->userSession = $userSession;
 		$this->ldapConnect = $ldapConnect;
-		$this->logger = $logger;
 		$this->ldapProvider = $ldapProvider;
+		$this->configuration = $configuration;
+		$this->l10n = $l10n;
+		$this->logger = $logger;
 
 		if($this->ldapConnect->groupsEnabled()) {
 			$this->makeLdapBackendFirst();

--- a/lib/LDAPUserManager.php
+++ b/lib/LDAPUserManager.php
@@ -118,6 +118,8 @@ class LDAPUserManager implements ILDAPUserPlugin {
 	 * @throws ServerNotAvailableException
 	 */
 	public function setDisplayName($uid, $displayName) {
+        trigger_error(__METHOD__);
+        $this->logger->error(__METHOD__, ['app' => 'ldap_write_support']);
 		$userDN = $this->getUserDN($uid);
 
 		$connection = $this->ldapProvider->getLDAPConnection($uid);
@@ -141,6 +143,10 @@ class LDAPUserManager implements ILDAPUserPlugin {
 			if (ldap_mod_replace($connection, $userDN, [$displayNameField => $displayName])) {
 				return $displayName;
 			}
+            trigger_error(print_r(['conn' => $connection,
+                                   'user' => $userDN,
+                                   'dpyField' => $displayNameField,
+                                   'dpy' => $displayName], true));
 			throw new HintException('Failed to set display name');
 		} catch (ConstraintViolationException $e) {
 			throw new HintException(

--- a/lib/Service/Configuration.php
+++ b/lib/Service/Configuration.php
@@ -56,6 +56,14 @@ class Configuration {
 		);
 	}
 
+	public function getGroupTemplate() {
+		return $this->config->getAppValue(
+			Application::APP_ID,
+			'template.group',
+			$this->getGroupTemplateDefault()
+		);
+	}
+
 	public function getUserTemplateDefault() {
 		return
 			'dn: uid={UID},{BASE}' . PHP_EOL .
@@ -65,6 +73,14 @@ class Configuration {
 			'cn: {UID}' . PHP_EOL .
 			'sn: {UID}' . PHP_EOL .
 			'userPassword: {PWD}';
+	}
+
+	public function getGroupTemplateDefault() {
+		return
+			'dn: cn={GID},{BASE}' . PHP_EOL .
+			'objectClass: groupOfNames' . PHP_EOL .
+			'cn: {GID}' . PHP_EOL .
+			'member:';
 	}
 
 	public function isRequireEmail(): bool {

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -53,7 +53,9 @@ class Admin implements ISettings {
 			'templates',
 			[
 				'user' => $this->config->getUserTemplate(),
-				'userDefault' => $this->config->getUserTemplateDefault(),
+				'userDefault' => $this->config->getGroupTemplateDefault(),
+				'group' => $this->config->getGroupTemplate(),
+				'groupDefault' => $this->config->getGroupTemplateDefault(),
 			]
 		);
 		$this->initialStateService->provideInitialState(

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -53,6 +53,13 @@
 			<li><span class="mono">{BASE}</span> – {{ t('ldap_write_support', 'the LDAP node of the acting (sub)admin or the configured user base') }}</li>
 		</ul>
 		<textarea class="mono" v-on:change="setUserTemplate" v-model="templates.user">{{templates.user}}</textarea>
+		<h3>{{ t('ldap_write_support', 'Group template') }}</h3>
+		<p>{{ t('ldap_write_support', 'LDIF template for creating groups. Following placeholders may be used') }}</p>
+		<ul class="disc">
+			<li><span class="mono">{GID}</span> – {{ t('ldap_write_support', 'the group id provided by the (sub)admin') }}</li>
+			<li><span class="mono">{BASE}</span> – {{ t('ldap_write_support', 'the LDAP node of the acting (sub)admin or the configured group base') }}</li>
+		</ul>
+		<textarea class="mono" v-on:change="setGroupTemplate" v-model="templates.group">{{templates.group}}</textarea>
 	</div>
 </template>
 
@@ -67,6 +74,8 @@
 			templates: {
 				user: Object,
 				userDefault: Object,
+				group: Object,
+				groupDefault: Object,
 			},
 			switches: {
 				createRequireActorFromLdap: Boolean,
@@ -91,6 +100,18 @@
 					return;
 				}
 				OCP.AppConfig.setValue('ldap_write_support', 'template.user', this.templates.user);
+			},
+			setGroupTemplate() {
+				if(this.templates.group === "") {
+					let self = this;
+					OCP.AppConfig.deleteKey('ldap_write_support', 'template.group', {
+						success: function() {
+							self.templates.group = self.templates.groupDefault;
+						}
+					});
+					return;
+				}
+				OCP.AppConfig.setValue('ldap_write_support', 'template.group', this.templates.group);
 			},
 			toggleSwitch(prefKey, state, appId = 'ldap_write_support') {
 				this.switches[prefKey] = state;


### PR DESCRIPTION
Rationale: this allows to support "custom" group LDAP classes, like the
groupOfMembers class of the rfc2307bis draft. The core user_ldap app
could also be changed to make this more handy, but already allows custom
group filters.

groupOfMembers and other custom group classes do not require a member attribute, i.e. it is possible to create empty groups without the "Gurkerei" of adding an empty member attribute.