### PR TITLE
works around calling occ issue on integration tests by relying on APi

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -15,6 +15,15 @@ steps:
       # Code checker
       - ./occ app:check-code $APP_NAME -c strong-comparison
       - ./occ app:check-code $APP_NAME -c deprecation
+  - name: syntax-php7.2
+    image: nextcloudci/php7.2:php7.2-14
+    environment:
+      APP_NAME: ldap_write_support
+      CORE_BRANCH: stable20
+      DB: sqlite
+    commands:
+      - composer install
+      - ./vendor/bin/parallel-lint --exclude ./vendor/ .
   - name: syntax-php7.3
     image: nextcloudci/php7.3:php7.3-5
     environment:
@@ -96,6 +105,90 @@ steps:
     environment:
       APP_NAME: ldap_write_support
       CORE_BRANCH: master
+      DB: sqlite
+    commands:
+      # Pre-setup steps
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
+      - cd ../server/
+      - php occ app:enable user_ldap
+      - php occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+      - cd tests/integration
+      - ./run.sh
+
+services:
+  - name: openldap
+    image: nextcloudci/openldap:openldap-7
+    environment:
+      SLAPD_DOMAIN: nextcloud.ci
+      SLAPD_ORGANIZATION: Nextcloud
+      SLAPD_PASSWORD: admin
+      SLAPD_ADDITIONAL_MODULES: memberof
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+    - pull_request
+    - push
+type: docker
+---
+kind: pipeline
+name: integration-stable20
+steps:
+  - name: integration
+    image: nextcloudci/php7.3:php7.3-5
+    environment:
+      APP_NAME: ldap_write_support
+      CORE_BRANCH: stable20
+      DB: sqlite
+    commands:
+      # Pre-setup steps
+      - wget https://raw.githubusercontent.com/nextcloud/travis_ci/master/before_install.sh
+      - bash ./before_install.sh $APP_NAME $CORE_BRANCH $DB
+      - cd ../server/
+      - php occ config:system:set redis host --value=cache
+      - php occ config:system:set redis port --value=6379 --type=integer
+      - php occ config:system:set redis timeout --value=0 --type=integer
+      - php occ config:system:set --type string --value "\\OC\\Memcache\\Redis" memcache.local
+      - php occ config:system:set --type string --value "\\OC\\Memcache\\Redis" memcache.distributed
+      - php occ app:enable user_ldap
+      - php occ app:enable $APP_NAME
+      - cd apps/$APP_NAME
+      - cd tests/integration
+      - ./run.sh
+
+services:
+  - name: cache
+    image: redis
+  - name: openldap
+    image: nextcloudci/openldap:openldap-7
+    environment:
+      SLAPD_DOMAIN: nextcloud.ci
+      SLAPD_ORGANIZATION: Nextcloud
+      SLAPD_PASSWORD: admin
+      SLAPD_ADDITIONAL_MODULES: memberof
+
+trigger:
+  branch:
+    - master
+    - stable*
+  event:
+    - pull_request
+    - push
+type: docker
+
+---
+kind: pipeline
+name: integration-stable20-nocache
+steps:
+  - name: integration
+    image: nextcloudci/php7.3:php7.3-5
+    environment:
+      APP_NAME: ldap_write_support
+      CORE_BRANCH: stable20
       DB: sqlite
     commands:
       # Pre-setup steps

--- a/tests/integration/features/bootstrap/FeatureContext.php
+++ b/tests/integration/features/bootstrap/FeatureContext.php
@@ -96,4 +96,13 @@ class FeatureContext extends LDAPContext implements Context {
 		}
 	}
 
+	/**
+	 * @Given /^user "([^"]*)" exists on "([^"]*)" backend$/
+	 */
+	public function userExistsOnBackend($uid, $backendName) {
+		$this->assureUserExists($uid);
+		$needle = '<backend>' . $backendName . '</backend>';
+		Assert::assertNotFalse(strpos($this->getResponse()->getBody()->getContents(), $needle));
+	}
+
 }

--- a/tests/integration/features/user.feature
+++ b/tests/integration/features/user.feature
@@ -19,11 +19,8 @@ Feature: user
       | password | 123456 |
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
-    And user "brand-new-user" exists
-    And invoking occ with "user:info brand-new-user"
-    And the command output contains the text "backend: LDAP"
+    And user "brand-new-user" exists on "LDAP" backend
 
-  # requires NC 17
   Scenario: create a new user with dynamic user id
     Given As an "admin"
     And parameter "newUser.generateUserID" of app "core" is set to "yes"
@@ -34,7 +31,6 @@ Feature: user
     And the HTTP status code should be "200"
     And the created users resides on LDAP
 
-  # requires NC 17
   Scenario: create a new user with dynamic user id without user base set
     Given As an "admin"
     And parameter "newUser.generateUserID" of app "core" is set to "yes"
@@ -47,7 +43,6 @@ Feature: user
     And the HTTP status code should be "200"
     And the created users resides on LDAP
 
-  # requires NC 17
   Scenario: create a new user with dynamic user id
     Given As an "admin"
     And parameter "newUser.generateUserID" of app "core" is set to "yes"
@@ -61,7 +56,6 @@ Feature: user
     When sending "GET" to "/cloud/users?search=Foo"
     Then it yields "1" result
 
-  # requires NC 17
   Scenario: create a new user with dynamic user id and required email
     Given As an "admin"
     And parameter "newUser.generateUserID" of app "core" is set to "yes"
@@ -73,7 +67,6 @@ Feature: user
     Then the OCS status code should be "200"
     And the HTTP status code should be "200"
 
-  # requires NC 17
   Scenario: create a new user with dynamic user id, forgot email
     Given As an "admin"
     And parameter "newUser.generateUserID" of app "core" is set to "yes"


### PR DESCRIPTION
For about a week we are having failing integration tests with

```
Failed asserting that 'Could not open input file: console.php\n
' contains "backend: LDAP".
```

and I could not really figure out why. But the information is fetched already through the users exists test by API. We are checking the response now instead.

