### PR TITLE
Use LDAP passwd exop to set password of new users

### DIFF
--- a/lib/LDAPUserManager.php
+++ b/lib/LDAPUserManager.php
@@ -247,6 +247,22 @@ class LDAPUserManager implements ILDAPUserPlugin {
 		if (!$ret && $this->configuration->isPreventFallback()) {
 			throw new \Exception('Cannot create user: ' . ldap_error($connection), ldap_errno($connection));
 		}
+
+		// Set password through ldap password exop, if supported
+		if ($this->respondToActions() & Backend::SET_PASSWORD) {
+			try {
+				$ret = ldap_exop_passwd($connection, $newUserDN, '', $password);
+				if ($ret === false) {
+					$message = 'Failed to set password for new user {dn}';
+					$this->logger->log(ILogger::ERROR, $message, [
+						'app' => Application::APP_ID,
+						'dn' => $newUserDN,
+					]);
+				}
+			} catch (\Exception $e) {
+				$this->logger->logException($e, ['app' => Application::APP_ID]);
+			}
+		} 
 		return $ret ? $newUserDN : false;
 	}
 

--- a/lib/Service/Configuration.php
+++ b/lib/Service/Configuration.php
@@ -63,8 +63,7 @@ class Configuration {
 			'uid: {UID}' . PHP_EOL .
 			'displayName: {UID}' . PHP_EOL .
 			'cn: {UID}' . PHP_EOL .
-			'sn: {UID}' . PHP_EOL .
-			'userPassword: {PWD}';
+			'sn: {UID}';
 	}
 
 	public function isRequireEmail(): bool {


### PR DESCRIPTION
* Supersedes: #87
* Resolves: #86

This is (just) a rebased version of #87 to prevent ldap from saving passwords of new users in clear text if no server side hashing is enabled.