### PR TITLE
Add support for full contact info

### DIFF
--- a/lib/Service/Configuration.php
+++ b/lib/Service/Configuration.php
@@ -48,6 +48,10 @@ class Configuration {
 		return $this->config->getAppValue('ldap_write_support', 'hasAvatarPermission', '1') === '1';
 	}
 
+	public function canUpdateContactInfo(): bool {
+		return $this->config->getAppValue('ldap_write_support', 'canUpdateContactInfo', '1') === '1';
+	}
+
 	public function getUserTemplate() {
 		return $this->config->getAppValue(
 			Application::APP_ID,

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -61,6 +61,7 @@ class Admin implements ISettings {
 				'createRequireActorFromLdap' => $this->config->isLdapActorRequired(),
 				'createPreventFallback' => $this->config->isPreventFallback(),
 				'hasAvatarPermission' => $this->config->hasAvatarPermission(),
+				'canUpdateContactInfo' => $this->config->canUpdateContactInfo(),
 				'newUserRequireEmail' => $this->config->isRequireEmail(),
 				'newUserGenerateUserID' => $this->config->isGenerateUserId(),
 			]

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -44,6 +44,10 @@
 				@change.stop.prevent="toggleSwitch('hasAvatarPermission', !switches.hasAvatarPermission)">
 				{{ t('ldap_write_support', 'Allow users to set their avatar') }}
 			</NcActionCheckbox>
+			<NcActionCheckbox :checked="switches.canUpdateContactInfo"
+				@change.stop.prevent="toggleSwitch('canUpdateContactInfo', !switches.canUpdateContactInfo)">
+				{{ t('ldap_write_support', 'Update LDAP/AD when contact info changes') }}
+			</NcActionCheckbox>
 		</ul>
 		<h3>{{ t('ldap_write_support', 'User template') }}</h3>
 		<p>{{ t('ldap_write_support', 'LDIF template for creating users. Following placeholders may be used') }}</p>


### PR DESCRIPTION
This PR adds a listener for event changes beyond just display name and email to cover off on contact fields. It leverages the `GenericEvent` response on the `OC\AccountManager::userUpdated` to map event arguments to LDAP/AD fields.

|Event argument|LDAP/AD field|
|-----------------------|---------------------|
|phone|telephoneNumber|
|address|l|
|website|wWWHomePage|
|organisation|department|
|role|title|
|biography|description|

I have tested this fairly extensively against a Samba 4 AD/LDAP setup.

If time permits I will be looking into the LDAP backend for querying this data on first user pull as well.