### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -735,12 +735,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "a8d9ce428b47455b4bd30170ae95c322cdbef6f6"
+                "reference": "71201322c342a48ebc0825fcdd5e7507eac47824"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/a8d9ce428b47455b4bd30170ae95c322cdbef6f6",
-                "reference": "a8d9ce428b47455b4bd30170ae95c322cdbef6f6",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/71201322c342a48ebc0825fcdd5e7507eac47824",
+                "reference": "71201322c342a48ebc0825fcdd5e7507eac47824",
                 "shasum": ""
             },
             "require": {
@@ -771,7 +771,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2024-03-05T00:31:32+00:00"
+            "time": "2024-03-12T00:31:36+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency