### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "54e519f73544c0b41d85f0979089af91eae30aba"
+                "reference": "a953c9a7eecc888d747b53ce3f08aafb119e483f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/54e519f73544c0b41d85f0979089af91eae30aba",
-                "reference": "54e519f73544c0b41d85f0979089af91eae30aba",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/a953c9a7eecc888d747b53ce3f08aafb119e483f",
+                "reference": "a953c9a7eecc888d747b53ce3f08aafb119e483f",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2024-12-07T00:47:06+00:00"
+            "time": "2024-12-11T00:48:24+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency