### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "4f4564017c7a4e2c4da6cea1fc4b11c8afd8fe0d"
+                "reference": "f4365e6adc2006a2971ed69d00615cf560a0bf40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/4f4564017c7a4e2c4da6cea1fc4b11c8afd8fe0d",
-                "reference": "4f4564017c7a4e2c4da6cea1fc4b11c8afd8fe0d",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f4365e6adc2006a2971ed69d00615cf560a0bf40",
+                "reference": "f4365e6adc2006a2971ed69d00615cf560a0bf40",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-03-21T00:47:07+00:00"
+            "time": "2025-03-29T00:46:23+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency