### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "8f470f66ec1d0d2e209c8a8a8a6ec30d4598e461"
+                "reference": "0424781bcc78bd70709b0ea86a6f47c2ecfd2267"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/8f470f66ec1d0d2e209c8a8a8a6ec30d4598e461",
-                "reference": "8f470f66ec1d0d2e209c8a8a8a6ec30d4598e461",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/0424781bcc78bd70709b0ea86a6f47c2ecfd2267",
+                "reference": "0424781bcc78bd70709b0ea86a6f47c2ecfd2267",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-04-24T00:50:06+00:00"
+            "time": "2025-05-01T00:56:04+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency