### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "97d7aa6e535670437a178084eea91a42998fef5c"
+                "reference": "9c1710075ffc568f6b804ac628b8fa990263db0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/97d7aa6e535670437a178084eea91a42998fef5c",
-                "reference": "97d7aa6e535670437a178084eea91a42998fef5c",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/9c1710075ffc568f6b804ac628b8fa990263db0f",
+                "reference": "9c1710075ffc568f6b804ac628b8fa990263db0f",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-06-13T00:53:13+00:00"
+            "time": "2025-06-25T00:54:25+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency