### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "587ae7f09700ce7d081b8bdc14064791b84fd5fb"
+                "reference": "8ec87be7ab634f12a403fca7165319587a6cb218"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/587ae7f09700ce7d081b8bdc14064791b84fd5fb",
-                "reference": "587ae7f09700ce7d081b8bdc14064791b84fd5fb",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/8ec87be7ab634f12a403fca7165319587a6cb218",
+                "reference": "8ec87be7ab634f12a403fca7165319587a6cb218",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-07-17T00:56:49+00:00"
+            "time": "2025-07-26T00:55:00+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency