### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "c2c75ad8fdc54cbc6341764b5a2a8ecf860e6160"
+                "reference": "01cf3974cbe9fa480702a32f5720e322f2340392"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/c2c75ad8fdc54cbc6341764b5a2a8ecf860e6160",
-                "reference": "c2c75ad8fdc54cbc6341764b5a2a8ecf860e6160",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/01cf3974cbe9fa480702a32f5720e322f2340392",
+                "reference": "01cf3974cbe9fa480702a32f5720e322f2340392",
                 "shasum": ""
             },
             "require": {
@@ -111,7 +111,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2025-08-10T01:01:23+00:00"
+            "time": "2025-08-16T00:51:51+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency