### PR TITLE
[stable31] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -70,12 +70,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "6f810d951d6a012d6365b9b7e60a95ba68fb5ca1"
+                "reference": "f8bed3678d4113a737fdc05dd70ee9884935d970"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6f810d951d6a012d6365b9b7e60a95ba68fb5ca1",
-                "reference": "6f810d951d6a012d6365b9b7e60a95ba68fb5ca1",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f8bed3678d4113a737fdc05dd70ee9884935d970",
+                "reference": "f8bed3678d4113a737fdc05dd70ee9884935d970",
                 "shasum": ""
             },
             "require": {
@@ -110,7 +110,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
             },
-            "time": "2026-04-23T01:28:54+00:00"
+            "time": "2026-06-26T02:11:11+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency